### PR TITLE
Add login tests

### DIFF
--- a/SeleniumAutomation/src/main/java/org/example/pages/SecureAreaPage.java
+++ b/SeleniumAutomation/src/main/java/org/example/pages/SecureAreaPage.java
@@ -1,0 +1,17 @@
+package org.example.pages;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class SecureAreaPage {
+    private WebDriver driver;
+    private By flashMessage = By.id("flash");
+
+    public SecureAreaPage(WebDriver driver) {
+        this.driver = driver;
+    }
+
+    public String getFlashMessage() {
+        return driver.findElement(flashMessage).getText();
+    }
+}

--- a/SeleniumAutomation/src/main/java/org/example/tests/LoginTest.java
+++ b/SeleniumAutomation/src/main/java/org/example/tests/LoginTest.java
@@ -1,0 +1,38 @@
+package org.example.tests;
+
+import org.example.pages.LoginPage;
+import org.example.pages.SecureAreaPage;
+import org.example.utils.NavigationHelper;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class LoginTest extends tests.BaseTest {
+
+    @Test
+    public void testValidLogin() {
+        NavigationHelper navigator = new NavigationHelper(driver);
+        navigator.navigateTo("/login");
+
+        LoginPage loginPage = new LoginPage(driver);
+        loginPage.enterUsername("tomsmith");
+        loginPage.enterPassword("SuperSecretPassword!");
+        loginPage.clickLogin();
+
+        SecureAreaPage secureArea = new SecureAreaPage(driver);
+        Assert.assertTrue(secureArea.getFlashMessage().contains("You logged into a secure area"));
+    }
+
+    @Test
+    public void testInvalidLogin() {
+        NavigationHelper navigator = new NavigationHelper(driver);
+        navigator.navigateTo("/login");
+
+        LoginPage loginPage = new LoginPage(driver);
+        loginPage.enterUsername("invalid");
+        loginPage.enterPassword("invalid");
+        loginPage.clickLogin();
+
+        SecureAreaPage secureArea = new SecureAreaPage(driver);
+        Assert.assertTrue(secureArea.getFlashMessage().contains("Your username is invalid"));
+    }
+}


### PR DESCRIPTION
## Summary
- add page object for secure area
- add login tests for valid and invalid credentials

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619519f1e4832e97632f75476c17de