### PR TITLE
Add table cell assertion in ChallengingDomTest

### DIFF
--- a/SeleniumAutomation/src/main/java/org/example/tests/ChallengingDomTest.java
+++ b/SeleniumAutomation/src/main/java/org/example/tests/ChallengingDomTest.java
@@ -16,6 +16,9 @@ public class ChallengingDomTest extends tests.BaseTest {
 
         Assert.assertTrue(page.isTableDisplayed());
         page.clickFirstButton();
+
+        String cellText = page.getCellData(1, 1);
+        Assert.assertFalse(cellText.isEmpty());
     }
 
 }


### PR DESCRIPTION
## Summary
- add retrieval of table cell after clicking button
- assert that the retrieved table cell text is not empty

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686197fcd9d8832ea0a713fb5eeaf05a